### PR TITLE
Fix SYR Trait value

### DIFF
--- a/Patches/Mods/[SYR]_Trait_Value.xml
+++ b/Patches/Mods/[SYR]_Trait_Value.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Patch>
 
 	<Operation Class="PatchOperationFindMod">
@@ -187,7 +187,18 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/TraitDef[defName = "FT_ActionBoy" or "FT_ActionGirl"]</xpath>
+				<xpath>Defs/TraitDef[defName = "FT_ActionGirl"]</xpath>
+				<value>
+				  <li Class="SyrTraitValue.TraitValueExtension">
+					<traitValues>
+					  <li>30</li>
+					</traitValues>
+				  </li>
+				</value>
+				</li>
+				
+				<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/TraitDef[defName = "FT_ActionBoy"]</xpath>
 				<value>
 				  <li Class="SyrTraitValue.TraitValueExtension">
 					<traitValues>
@@ -341,7 +352,7 @@
 				<value>
 				  <li Class="SyrTraitValue.TraitValueExtension">
 					<traitValues>
-					  <li>20</li>
+					  <li>1, 20</li>
 					</traitValues>
 				  </li>
 				</value>

--- a/Patches/Mods/[SYR]_Trait_Value.xml
+++ b/Patches/Mods/[SYR]_Trait_Value.xml
@@ -187,7 +187,11 @@
 				</li>
 
 				<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/TraitDef[defName = "FT_ActionGirl"]</xpath>
+				<xpath>
+					Defs/TraitDef[
+						defName = "FT_ActionBoy" or 
+						defName = "FT_ActionGirl"]
+				</xpath>
 				<value>
 				  <li Class="SyrTraitValue.TraitValueExtension">
 					<traitValues>
@@ -197,16 +201,6 @@
 				</value>
 				</li>
 				
-				<li Class="PatchOperationAddModExtension">
-				<xpath>Defs/TraitDef[defName = "FT_ActionBoy"]</xpath>
-				<value>
-				  <li Class="SyrTraitValue.TraitValueExtension">
-					<traitValues>
-					  <li>30</li>
-					</traitValues>
-				  </li>
-				</value>
-				</li>
 
 				<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/TraitDef[defName = "FT_QuickHands"]</xpath>

--- a/Patches/Mods/[SYR]_Trait_Value.xml
+++ b/Patches/Mods/[SYR]_Trait_Value.xml
@@ -200,7 +200,7 @@
 				  </li>
 				</value>
 				</li>
-				
+
 				<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/TraitDef[defName = "FT_QuickHands"]</xpath>
 				<value>

--- a/Patches/Mods/[SYR]_Trait_Value.xml
+++ b/Patches/Mods/[SYR]_Trait_Value.xml
@@ -201,7 +201,6 @@
 				</value>
 				</li>
 				
-
 				<li Class="PatchOperationAddModExtension">
 				<xpath>Defs/TraitDef[defName = "FT_QuickHands"]</xpath>
 				<value>


### PR DESCRIPTION
Fixes the error for SYR Trait Framework menu. Had to separate the action boy/girl and add a degree to FT_Philanthropist since base has a degree value for some reason (you could remove either the degree on the trait or add a degree to the patch).